### PR TITLE
Update demo to v2 widget and add details in README

### DIFF
--- a/demo/README
+++ b/demo/README
@@ -1,6 +1,0 @@
-This program needs a "keys.yml" file with the following elements:
-
-ikey: your_duo_integration_key_here
-skey: your_duo_secret_key_here
-akey: your_application_secret_key_here
-host: your_duo_api_host_here

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,23 @@
+# Demo app
+
+This program needs a "keys.yml" file with the following elements:
+
+```yaml
+---
+ikey: duo_integration_key
+skey: duo_secrect_key
+akey: your_application_key # generate one with: openssl rand -hex 20
+host: duo_api_host
+```
+
+Create one or copy and edit `keys-template.yml`
+
+## Steps
+
+- Create a new application in your Duo Security account. Get the keys and API hostname
+- Edit the keys.yml file with your credentials (or copy and use `-c your-keys-file.yml`)
+- Get the Duo Security Javascript file and put it in static/: `curl -L -o static/Duo-Web-v2.min.js https://raw.githubusercontent.com/duosecurity/duo_python/master/js/Duo-Web-v2.min.js`
+- `go get` to get dependencies
+- `go build` to build `demo`
+- Run `./demo`
+- Test it out!

--- a/demo/keys.yml
+++ b/demo/keys.yml
@@ -1,0 +1,5 @@
+---
+ikey: duo_integration_key
+skey: duo_secrect_key
+akey: your_application_key # generate one with: openssl rand -hex 20
+host: duo_api_host

--- a/demo/main.go
+++ b/demo/main.go
@@ -16,6 +16,7 @@ import (
 func main() {
 	port := flag.Int("p", 8080, "port to listen on")
 	cfgFile := flag.String("c", "keys.yml", "config file")
+	flag.Parse()
 
 	cfgData, err := ioutil.ReadFile(*cfgFile)
 	if err != nil {
@@ -113,13 +114,26 @@ func main() {
 
 var getTMPL = template.Must(template.New("gettmpl").Parse(
 	`<html><head></head>
-<body>
-    <script src='/static/Duo-Web-v1.bundled.min.js'></script>
-    <script>
-        Duo.init({'host':'{{ .Host }}', 'sig_request':'{{ .SigRequest }} '});
-    </script>
-    <iframe height='500' width='620' frameborder='0' id='duo_iframe' />
-</body>`))
+	<body>
+	<script src='/static/Duo-Web-v2.min.js'></script>
+		<script>
+			Duo.init({'host':'{{ .Host }}', 'sig_request':'{{ .SigRequest }} '});
+		</script>
+		<iframe id="duo_iframe"
+			data-host="{{ .Host }}"
+			data-sig-request="{{ .SigRequest }}">
+		</iframe>
+		<style>
+		#duo_iframe {
+			width: 100%;
+			min-width: 304px;
+			max-width: 620px;
+			height: 330px;
+			border: none;
+		}
+		</style>
+	</body>
+</html>`))
 
 var welcomeTMPL = template.Must(template.New("welcome").Parse(
 	`<html><head></head>

--- a/demo/static/README
+++ b/demo/static/README
@@ -1,5 +1,0 @@
-Please run: 
-
-    curl -O https://raw.github.com/duosecurity/duo_python/master/js/Duo-Web-v1.bundled.min.js
-
-to download the required javascript file.

--- a/demo/static/README.md
+++ b/demo/static/README.md
@@ -1,0 +1,7 @@
+Please run:
+
+```shell
+curl -L -o Duo-Web-v2.min.js https://raw.githubusercontent.com/duosecurity/duo_python/master/js/Duo-Web-v2.min.js
+```
+
+to download the required javascript file.


### PR DESCRIPTION
- Added more details in the demo/README file (and promoted it to a markdown document). 
- Updated the demo app to use Duo Security v2 widget
- Added flag.Parse() to actually parse the flags for the demo app

I've done a quick test and I can authenticate and/or enroll. I'm not sure that the enroll steps are required anymore as it seems like the widget handles that now. 